### PR TITLE
Remove KMS dependency on Kubernetes and Etcd quoins

### DIFF
--- a/etcd/bootstrapper/s3-cloudconfig-bootstrap.sh
+++ b/etcd/bootstrapper/s3-cloudconfig-bootstrap.sh
@@ -49,33 +49,7 @@ docker run --rm --name s3cp-common-tls -v "$work_dir":"$work_dir" "$image" /bin/
 # Replace placeholders inside cloud-config
 sed -i -- 's/\\$private_ipv4/'$private_ipv4'/g; s/\\$public_ipv4/'$public_ipv4'/g' $work_dir/cloud-config.yaml
 
-# Decode TLS Assets
-echo "Decoding TLS assets"
-for encPemFile in $work_dir/tls/*.pem.enc.base; do
-  echo "Decoding $encPemFile"
-  cat $encPemFile | base64 -d > $${encPemFile%.base}
-done
-
-# Decrypt TLS Assets
-docker run --rm --name decrypt-tls \
-  -e REGION=$region \
-  -e WORK_DIR=$work_dir/tls \
-  -v $work_dir/tls:$work_dir/tls \
-  quay.io/concur_platform/awscli:0.1.1 /bin/bash \
-    -ec \
-    'echo Decrypting TLS assets; \
-    shopt -s nullglob; \
-    for encPemFile in $WORK_DIR/*.pem.enc; do \
-      echo Decrypting $encPemFile; \
-      /usr/bin/aws \
-        --region $REGION kms decrypt \
-        --ciphertext-blob fileb://$encPemFile \
-        --output text \
-        --query Plaintext \
-      | base64 -d > $${encPemFile%.enc}; \
-    done; \
-    cat $WORK_DIR/intermediate-ca.pem $WORK_DIR/root-ca.pem > $WORK_DIR/ca-chain.pem; \
-    echo done.'
+sed -i -- 's;\$etcd_cluster_name;'$bucket';g' $work_dir/cloud-config.yaml
 
 # Create /etc/quoin-environment
 quoin_cluster_environment='/etc/quoin-environment'

--- a/etcd/cloud-configs/etcd.yaml
+++ b/etcd/cloud-configs/etcd.yaml
@@ -126,7 +126,12 @@ write_files:
       #!/bin/bash
 
       mkdir -p /etc/etcd/tls
-      mv /root/cloudinit/tls/*.pem /etc/etcd/tls
+      chmod 755 /root/cloudinit/tls/tls-provision.sh
+      cd /root/cloudinit/tls
+      ./tls-provision.sh generate-ca $etcd_cluster_name
+      ./tls-provision.sh generate-assets $etcd_cluster_name
+      mv /root/cloudinit/tls/tls_ca/*.pem /etc/etcd/tls
+      mv /root/cloudinit/tls/tls_assets/*.pem /etc/etcd/tls
   - path: /opt/bin/etcd-init.sh
     permissions: 0700
     owner: root:root

--- a/etcd/etcd.tf
+++ b/etcd/etcd.tf
@@ -8,30 +8,6 @@ variable "subnet_ids" {
   description = "A comma-separated list of subnet ids to use for the instances."
 }
 
-variable "etcd_server_cert" {
-  description = "The public certificate to be used by etcd servers encoded in base64 format."
-}
-
-variable "etcd_server_key" {
-  description = "The private key to be used by etcd servers encoded in base64 format."
-}
-
-variable "etcd_client_cert" {
-  description = "The public client certificate to be used for authenticating against etcd encoded in base64 format."
-}
-
-variable "etcd_client_key" {
-  description = "The client private key to be used for authenticating against etcd encoded in base64 format."
-}
-
-variable "etcd_peer_cert" {
-  description = "The public certificate to be used by etcd peers encoded in base64 format."
-}
-
-variable "etcd_peer_key" {
-  description = "The private key to be used by etcd peers encoded in base64 format."
-}
-
 variable "etcd_instance_type" {
   description = "The type of instance to use for the etcd cluster. Example: 'm3.medium'"
   default     = "m3.medium"
@@ -190,43 +166,6 @@ resource "aws_s3_bucket_object" "etcd" {
   content = "${data.template_file.etcd.rendered}"
 }
 
-# Certificates
-resource "aws_s3_bucket_object" "etcd_server_cert" {
-  bucket  = "${aws_s3_bucket.cluster.bucket}"
-  key     = "cloudinit/etcd/tls/etcd-server.pem.enc.base"
-  content = "${var.etcd_server_cert}"
-}
-
-resource "aws_s3_bucket_object" "etcd_server_key" {
-  bucket  = "${aws_s3_bucket.cluster.bucket}"
-  key     = "cloudinit/etcd/tls/etcd-server-key.pem.enc.base"
-  content = "${var.etcd_server_key}"
-}
-
-resource "aws_s3_bucket_object" "etcd_client_cert" {
-  bucket  = "${aws_s3_bucket.cluster.bucket}"
-  key     = "cloudinit/common/tls/etcd-client.pem.enc.base"
-  content = "${var.etcd_client_cert}"
-}
-
-resource "aws_s3_bucket_object" "etcd_client_key" {
-  bucket  = "${aws_s3_bucket.cluster.bucket}"
-  key     = "cloudinit/common/tls/etcd-client-key.pem.enc.base"
-  content = "${var.etcd_client_key}"
-}
-
-resource "aws_s3_bucket_object" "etcd_peer_cert" {
-  bucket  = "${aws_s3_bucket.cluster.bucket}"
-  key     = "cloudinit/etcd/tls/etcd-peer.pem.enc.base"
-  content = "${var.etcd_peer_cert}"
-}
-
-resource "aws_s3_bucket_object" "etcd_peer_key" {
-  bucket  = "${aws_s3_bucket.cluster.bucket}"
-  key     = "cloudinit/etcd/tls/etcd-peer-key.pem.enc.base"
-  content = "${var.etcd_peer_key}"
-}
-
 # Profile, Role, and Policy
 resource "aws_iam_instance_profile" "etcd" {
   name       = "${format("%s-%s-%s", var.name, var.region, var.version)}"
@@ -259,7 +198,6 @@ data "template_file" "etcd_policy" {
 
   vars {
     name        = "${var.name}"
-    kms_key_arn = "${var.kms_key_arn}"
   }
 }
 

--- a/etcd/main.tf
+++ b/etcd/main.tf
@@ -25,16 +25,8 @@ variable "cost_center" {
   description = "The cost center to attach resource usage."
 }
 
-variable "kms_key_arn" {
-  description = "The arn associated with the encryption key used for encrypting the certificates."
-}
-
-variable "root_cert" {
-  description = "The root certificate authority that all certificates belong to encoded in base64 format."
-}
-
-variable "intermediate_cert" {
-  description = "The intermediate certificate authority that all certificates belong to encoded in base64 format."
+variable "tls_provision" {
+  description = "The TLS ca and assets provision script."
 }
 
 variable "vpc_id" {
@@ -55,17 +47,11 @@ variable "availability_zones" {
 * ------------------------------------------------------------------------------
 */
 
-# Certificates
-resource "aws_s3_bucket_object" "root_cert" {
+# Certificates Provision Script
+resource "aws_s3_bucket_object" "tls_provision" {
   bucket  = "${aws_s3_bucket.cluster.bucket}"
-  key     = "cloudinit/common/tls/root-ca.pem.enc.base"
-  content = "${var.root_cert}"
-}
-
-resource "aws_s3_bucket_object" "intermediate_cert" {
-  bucket  = "${aws_s3_bucket.cluster.bucket}"
-  key     = "cloudinit/common/tls/intermediate-ca.pem.enc.base"
-  content = "${var.intermediate_cert}"
+  key     = "cloudinit/common/tls/tls-provision.sh"
+  content = "${var.tls_provision}"
 }
 
 /*

--- a/etcd/policies/etcd-policy.json
+++ b/etcd/policies/etcd-policy.json
@@ -16,15 +16,6 @@
     {
       "Effect": "Allow",
       "Action": [
-        "kms:Decrypt"
-      ],
-      "Resource": [
-        "${kms_key_arn}"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
         "ec2:Describe*",
         "autoscaling:Describe*"
       ],

--- a/kubernetes/cloud-configs/controller.yaml
+++ b/kubernetes/cloud-configs/controller.yaml
@@ -9,6 +9,7 @@ coreos:
       runtime: true
       content: |
         [Unit]
+        After=kubelet.service docker.service
         Wants=kubelet.service docker.service
 
         [Service]
@@ -25,7 +26,8 @@ coreos:
       enable: true
       content: |
         [Unit]
-        Wants=flanneld.service
+        After=flanneld.service docker.service
+        Wants=flanneld.service docker.service
 
         [Service]
         ExecStartPre=/usr/bin/systemctl is-active flanneld.service
@@ -175,6 +177,8 @@ coreos:
       content: |
         [Unit]
         Before=flanneld.service
+        After=prepare-tls-assets.service
+        Wants=prepare-tls-assets.service
 
         [Service]
         Type=simple
@@ -191,7 +195,7 @@ coreos:
       enable: true
       content: |
         [Unit]
-        Description=Prepare etcd TLS assets
+        Description=Prepare TLS assets
         Before=etcd-cluster-health.service
 
         [Service]
@@ -217,18 +221,18 @@ write_files:
       COREOS_PUBLIC_IPV4=$public_ipv4
       COREOS_PRIVATE_IPV4=$private_ipv4
       ETCDCTL_API=3
-      ETCDCTL_CA_FILE=/etc/kubernetes/tls/ca-chain.pem
-      ETCDCTL_CERT_FILE=/etc/kubernetes/tls/etcd-client.pem
-      ETCDCTL_KEY_FILE=/etc/kubernetes/tls/etcd-client-key.pem
+      ETCDCTL_CA_FILE=/etc/kubernetes/tls-etcd/ca-chain.pem
+      ETCDCTL_CERT_FILE=/etc/kubernetes/tls-etcd/etcd-client.pem
+      ETCDCTL_KEY_FILE=/etc/kubernetes/tls-etcd/etcd-client-key.pem
   - path: /etc/flannel/options.env
     permissions: 0644
     content: |
-      ETCD_SSL_DIR=/etc/kubernetes/tls
+      ETCD_SSL_DIR=/etc/kubernetes/tls-etcd
       FLANNELD_IFACE=$private_ipv4
       FLANNELD_ETCD_ENDPOINTS=$etcd_endpoint_urls
-      FLANNELD_ETCD_CAFILE=/etc/kubernetes/tls/ca-chain.pem
-      FLANNELD_ETCD_CERTFILE=/etc/kubernetes/tls/etcd-client.pem
-      FLANNELD_ETCD_KEYFILE=/etc/kubernetes/tls/etcd-client-key.pem
+      FLANNELD_ETCD_CAFILE=/etc/kubernetes/tls-etcd/ca-chain.pem
+      FLANNELD_ETCD_CERTFILE=/etc/kubernetes/tls-etcd/etcd-client.pem
+      FLANNELD_ETCD_KEYFILE=/etc/kubernetes/tls-etcd/etcd-client-key.pem
   - path: /etc/kubernetes/cni/net.d/10-flannel.conf
     permissions: 0644
     content: |
@@ -246,7 +250,19 @@ write_files:
       #!/bin/bash
 
       mkdir -p /etc/kubernetes/tls
-      mv /root/cloudinit/tls/*.pem /etc/kubernetes/tls
+      chmod 755 /root/cloudinit/tls/tls-provision.sh
+      cd /root/cloudinit/tls
+      ./tls-provision.sh generate-ca $k8s_cluster_name
+      ./tls-provision.sh generate-assets $k8s_cluster_name
+      mv /root/cloudinit/tls/tls_ca/*.pem /etc/kubernetes/tls
+      mv /root/cloudinit/tls/tls_assets/*.pem /etc/kubernetes/tls
+
+      mkdir -p /etc/kubernetes/tls-etcd
+      etcd_pki=$k8s_cluster_name
+      ./tls-provision.sh generate-ca "$etcd_pki-etcd"
+      ./tls-provision.sh generate-assets "$etcd_pki-etcd"
+      mv /root/cloudinit/tls/tls_ca/*.pem /etc/kubernetes/tls-etcd
+      mv /root/cloudinit/tls/tls_assets/*.pem /etc/kubernetes/tls-etcd
   - path: /opt/bin/docker-gc.sh
     permissions: 0700
     owner: root
@@ -343,9 +359,9 @@ write_files:
           - --runtime-config=extensions/v1beta1/networkpolicies=true
           - --anonymous-auth=false
           - --storage-backend=etcd3
-          - --etcd-cafile=/etc/kubernetes/tls/ca-chain.pem
-          - --etcd-certfile=/etc/kubernetes/tls/etcd-client.pem
-          - --etcd-keyfile=/etc/kubernetes/tls/etcd-client-key.pem
+          - --etcd-cafile=/etc/kubernetes/tls-etcd/ca-chain.pem
+          - --etcd-certfile=/etc/kubernetes/tls-etcd/etcd-client.pem
+          - --etcd-keyfile=/etc/kubernetes/tls-etcd/etcd-client-key.pem
           - --cloud-provider=aws
           livenessProbe:
             httpGet:
@@ -365,6 +381,9 @@ write_files:
           - mountPath: /etc/kubernetes/tls
             name: tls-certs-kubernetes
             readOnly: true
+          - mountPath: /etc/kubernetes/tls-etcd
+            name: tls-certs-etcd
+            readOnly: true
           - mountPath: /etc/tls/certs
             name: tls-certs-host
             readOnly: true
@@ -372,6 +391,9 @@ write_files:
         - hostPath:
             path: /etc/kubernetes/tls
           name: tls-certs-kubernetes
+        - hostPath:
+            path: /etc/kubernetes/tls-etcd
+          name: tls-certs-etcd
         - hostPath:
             path: /usr/share/ca-certificates
           name: tls-certs-host

--- a/kubernetes/cloud-configs/node.yaml
+++ b/kubernetes/cloud-configs/node.yaml
@@ -7,6 +7,7 @@ coreos:
       command: start
       content: |
         [Unit]
+        After=flanneld.service docker.service
         Wants=flanneld.service docker.service
 
         [Service]
@@ -219,6 +220,8 @@ coreos:
       content: |
         [Unit]
         Before=flanneld.service
+        After=prepare-tls-assets.service
+        Wants=prepare-tls-assets.service
 
         [Service]
         Type=simple
@@ -260,18 +263,18 @@ write_files:
       COREOS_PUBLIC_IPV4=$public_ipv4
       COREOS_PRIVATE_IPV4=$private_ipv4
       ETCDCTL_API=3
-      ETCDCTL_CA_FILE=/etc/kubernetes/tls/ca-chain.pem
-      ETCDCTL_CERT_FILE=/etc/kubernetes/tls/etcd-client.pem
-      ETCDCTL_KEY_FILE=/etc/kubernetes/tls/etcd-client-key.pem
+      ETCDCTL_CA_FILE=/etc/kubernetes/tls-etcd/ca-chain.pem
+      ETCDCTL_CERT_FILE=/etc/kubernetes/tls-etcd/etcd-client.pem
+      ETCDCTL_KEY_FILE=/etc/kubernetes/tls-etcd/etcd-client-key.pem
   - path: /etc/flannel/options.env
     permissions: 0644
     content: |
-      ETCD_SSL_DIR=/etc/kubernetes/tls
+      ETCD_SSL_DIR=/etc/kubernetes/tls-etcd
       FLANNELD_IFACE=$private_ipv4
       FLANNELD_ETCD_ENDPOINTS=$etcd_endpoint_urls
-      FLANNELD_ETCD_CAFILE=/etc/kubernetes/tls/ca-chain.pem
-      FLANNELD_ETCD_CERTFILE=/etc/kubernetes/tls/etcd-client.pem
-      FLANNELD_ETCD_KEYFILE=/etc/kubernetes/tls/etcd-client-key.pem
+      FLANNELD_ETCD_CAFILE=/etc/kubernetes/tls-etcd/ca-chain.pem
+      FLANNELD_ETCD_CERTFILE=/etc/kubernetes/tls-etcd/etcd-client.pem
+      FLANNELD_ETCD_KEYFILE=/etc/kubernetes/tls-etcd/etcd-client-key.pem
   - path: /etc/kubernetes/cni/net.d/10-flannel.conf
     permissions: 0644
     content: |
@@ -289,7 +292,19 @@ write_files:
       #!/bin/bash
 
       mkdir -p /etc/kubernetes/tls
-      mv /root/cloudinit/tls/*.pem /etc/kubernetes/tls
+      chmod 755 /root/cloudinit/tls/tls-provision.sh
+      cd /root/cloudinit/tls
+      ./tls-provision.sh generate-ca $k8s_cluster_name
+      ./tls-provision.sh generate-assets $k8s_cluster_name
+      mv /root/cloudinit/tls/tls_ca/*.pem /etc/kubernetes/tls
+      mv /root/cloudinit/tls/tls_assets/*.pem /etc/kubernetes/tls
+
+      mkdir -p /etc/kubernetes/tls-etcd
+      etcd_pki=$k8s_cluster_name
+      ./tls-provision.sh generate-ca "$etcd_pki-etcd"
+      ./tls-provision.sh generate-assets "$etcd_pki-etcd"
+      mv /root/cloudinit/tls/tls_ca/*.pem /etc/kubernetes/tls-etcd
+      mv /root/cloudinit/tls/tls_assets/*.pem /etc/kubernetes/tls-etcd
   - path: /opt/bin/docker-gc.sh
     permissions: 0700
     owner: root

--- a/kubernetes/controller.tf
+++ b/kubernetes/controller.tf
@@ -4,14 +4,6 @@
 * ------------------------------------------------------------------------------
 */
 
-variable "api_server_cert" {
-  description = "The public certificate to be used by k8s api servers encoded in base64 format."
-}
-
-variable "api_server_key" {
-  description = "The private key to be used by k8s api servers encoded in base64 format."
-}
-
 variable "controller_instance_type" {
   description = "The type of instance to use for the controller cluster. Example: 'm3.medium'"
   default     = "m3.medium"
@@ -187,19 +179,6 @@ resource "aws_s3_bucket_object" "controller" {
   content = "${data.template_file.controller.rendered}"
 }
 
-# Certificates
-resource "aws_s3_bucket_object" "api_server_cert" {
-  bucket  = "${aws_s3_bucket.cluster.bucket}"
-  key     = "cloudinit/controller/tls/api-server.pem.enc.base"
-  content = "${var.api_server_cert}"
-}
-
-resource "aws_s3_bucket_object" "api_server_key" {
-  bucket  = "${aws_s3_bucket.cluster.bucket}"
-  key     = "cloudinit/controller/tls/api-server-key.pem.enc.base"
-  content = "${var.api_server_key}"
-}
-
 # Profile, Role, and Policy
 resource "aws_iam_instance_profile" "controller" {
   name       = "${format("%s-controller-%s-%s", var.name, var.region, var.version)}"
@@ -232,7 +211,6 @@ data "template_file" "controller_policy" {
 
   vars {
     name        = "${var.name}"
-    kms_key_arn = "${var.kms_key_arn}"
   }
 }
 

--- a/kubernetes/etcd.tf
+++ b/kubernetes/etcd.tf
@@ -4,30 +4,6 @@
 * ------------------------------------------------------------------------------
 */
 
-variable "etcd_server_cert" {
-  description = "The public certificate to be used by etcd servers encoded in base64 format."
-}
-
-variable "etcd_server_key" {
-  description = "The private key to be used by etcd servers encoded in base64 format."
-}
-
-variable "etcd_client_cert" {
-  description = "The public client certificate to be used for authenticating against etcd encoded in base64 format."
-}
-
-variable "etcd_client_key" {
-  description = "The client private key to be used for authenticating against etcd encoded in base64 format."
-}
-
-variable "etcd_peer_cert" {
-  description = "The public certificate to be used by etcd peers encoded in base64 format."
-}
-
-variable "etcd_peer_key" {
-  description = "The private key to be used by etcd peers encoded in base64 format."
-}
-
 variable "etcd_instance_type" {
   description = "The type of instance to use for the etcd cluster. Example: 'm3.medium'"
   default     = "m3.medium"
@@ -74,16 +50,8 @@ module "etcd" {
   vpc_cidr                  = "${var.vpc_cidr}"
   availability_zones        = "${var.availability_zones}"
   subnet_ids                = "${join(",", aws_subnet.internal.*.id)}"
-  kms_key_arn               = "${var.kms_key_arn}"
   key_name                  = "${module.key_pair.key_name}"
-  root_cert                 = "${var.root_cert}"
-  intermediate_cert         = "${var.intermediate_cert}"
-  etcd_server_cert          = "${var.etcd_server_cert}"
-  etcd_server_key           = "${var.etcd_server_key}"
-  etcd_client_cert          = "${var.etcd_client_cert}"
-  etcd_client_key           = "${var.etcd_client_key}"
-  etcd_peer_cert            = "${var.etcd_peer_cert}"
-  etcd_peer_key             = "${var.etcd_peer_key}"
+  tls_provision             = "${var.tls_provision}"
   etcd_instance_type        = "${var.etcd_instance_type}"
   etcd_min_size             = "${var.etcd_min_size}"
   etcd_max_size             = "${var.etcd_max_size}"

--- a/kubernetes/main.tf
+++ b/kubernetes/main.tf
@@ -75,33 +75,19 @@
 *   external_subnets                      = "172.16.0.0/24,172.16.1.0/24,172.16.2.0/24"
 *   internal_subnets                      = "172.16.3.0/24,172.16.4.0/24,172.16.5.0/24"
 *   public_key                            = "${file(format("%s/keys/%s.pub", path.cwd, var.name))}"
-*   kms_key_arn                           = "arn:aws:kms:us-west-2:208127133681:key/709b95f1-90b0-46d3-b1d3-619fb4dfb82a"
-*   root_cert                             = "${file(format("%s/certs/root-ca.pem.enc.base", path.cwd))}"
-*   intermediate_cert                     = "${file(format("%s/certs/intermediate-ca.pem.enc.base", path.cwd))}"
-*   etcd_server_cert                      = "${file(format("%s/certs/etcd-server.pem.enc.base", path.cwd))}"
-*   etcd_server_key                       = "${file(format("%s/certs/etcd-server-key.pem.enc.base", path.cwd))}"
-*   etcd_client_cert                      = "${file(format("%s/certs/etcd-client.pem.enc.base", path.cwd))}"
-*   etcd_client_key                       = "${file(format("%s/certs/etcd-client-key.pem.enc.base", path.cwd))}"
-*   etcd_peer_cert                        = "${file(format("%s/certs/etcd-peer.pem.enc.base", path.cwd))}"
-*   etcd_peer_key                         = "${file(format("%s/certs/etcd-peer-key.pem.enc.base", path.cwd))}"
+*   tls_provision                         = "${file(format("%s/../provision.sh", path.cwd))}"
 *   etcd_instance_type                    = "m3.medium"
 *   etcd_min_size                         = "1"
 *   etcd_max_size                         = "9"
 *   etcd_desired_capacity                 = "1"
 *   etcd_root_volume_size                 = "12"
 *   etcd_data_volume_size                 = "12"
-*   api_server_cert                       = "${file(format("%s/certs/apiserver.pem.enc.base", path.cwd))}"
-*   api_server_key                        = "${file(format("%s/certs/apiserver-key.pem.enc.base", path.cwd))}"
 *   controller_instance_type              = "m3.medium"
 *   controller_min_size                   = "1"
 *   controller_max_size                   = "3"
 *   controller_desired_capacity           = "1"
 *   controller_root_volume_size           = "12"
 *   controller_docker_volume_size         = "12"
-*   node_cert                             = "${file(format("%s/certs/node.pem.enc.base", path.cwd))}"
-*   node_key                              = "${file(format("%s/certs/node-key.pem.enc.base", path.cwd))}"
-*   api_server_client_cert                = "${file(format("%s/certs/apiserver-client.pem.enc.base", path.cwd))}"
-*   api_server_client_key                 = "${file(format("%s/certs/apiserver-client-key.pem.enc.base", path.cwd))}"
 *   node_instance_type                    = "m3.medium"
 *   node_min_size                         = "1"
 *   node_max_size                         = "18"
@@ -152,16 +138,8 @@ variable "cost_center" {
   description = "The cost center to attach resource usage."
 }
 
-variable "kms_key_arn" {
-  description = "The arn associated with the encryption key used for encrypting the certificates."
-}
-
-variable "root_cert" {
-  description = "The root certificate authority that all certificates belong to encoded in base64 format."
-}
-
-variable "intermediate_cert" {
-  description = "The intermediate certificate authority that all certificates belong to encoded in base64 format."
+variable "tls_provision" {
+  description = "The TLS ca and assets provision script."
 }
 
 variable "kubernetes_hyperkube_image_repo" {
@@ -272,17 +250,17 @@ resource "aws_security_group" "kubernetes" {
   }
 }
 
-# Certificates
-resource "aws_s3_bucket_object" "root_cert" {
-  bucket  = "${aws_s3_bucket.cluster.bucket}"
-  key     = "cloudinit/common/tls/root-ca.pem.enc.base"
-  content = "${var.root_cert}"
-}
+/*
+* ------------------------------------------------------------------------------
+* Resources
+* ------------------------------------------------------------------------------
+*/
 
-resource "aws_s3_bucket_object" "intermediate_cert" {
+# Certificates Provision Script
+resource "aws_s3_bucket_object" "tls_provision" {
   bucket  = "${aws_s3_bucket.cluster.bucket}"
-  key     = "cloudinit/common/tls/intermediate-ca.pem.enc.base"
-  content = "${var.intermediate_cert}"
+  key     = "cloudinit/common/tls/tls-provision.sh"
+  content = "${var.tls_provision}"
 }
 
 /*

--- a/kubernetes/node.tf
+++ b/kubernetes/node.tf
@@ -3,23 +3,6 @@
 * Variables
 * ------------------------------------------------------------------------------
 */
-
-variable "node_cert" {
-  description = "The public certificate to be used by k8s nodes encoded in base64 format."
-}
-
-variable "node_key" {
-  description = "The private key to be used by k8s nodes encoded in base64 format."
-}
-
-variable "api_server_client_cert" {
-  description = "The public client certificate to be used for authenticating against k8s api server encoded in base64 format."
-}
-
-variable "api_server_client_key" {
-  description = "The client private key to be used for authenticating against k8s api server encoded in base64 format."
-}
-
 variable "node_instance_type" {
   description = "The type of instance to use for the node cluster. Example: 'm3.medium'"
   default     = "m3.medium"
@@ -160,31 +143,6 @@ resource "aws_s3_bucket_object" "node" {
   content = "${data.template_file.node.rendered}"
 }
 
-# Certificates
-resource "aws_s3_bucket_object" "node_cert" {
-  bucket  = "${aws_s3_bucket.cluster.bucket}"
-  key     = "cloudinit/node/tls/node.pem.enc.base"
-  content = "${var.node_cert}"
-}
-
-resource "aws_s3_bucket_object" "node_key" {
-  bucket  = "${aws_s3_bucket.cluster.bucket}"
-  key     = "cloudinit/node/tls/node-key.pem.enc.base"
-  content = "${var.node_key}"
-}
-
-resource "aws_s3_bucket_object" "api_server_client_cert" {
-  bucket  = "${aws_s3_bucket.cluster.bucket}"
-  key     = "cloudinit/node/tls/api-server-client.pem.enc.base"
-  content = "${var.api_server_client_cert}"
-}
-
-resource "aws_s3_bucket_object" "api_server_client_key" {
-  bucket  = "${aws_s3_bucket.cluster.bucket}"
-  key     = "cloudinit/node/tls/api-server-client-key.pem.enc.base"
-  content = "${var.api_server_client_key}"
-}
-
 # Profile, Role, and Policy
 resource "aws_iam_instance_profile" "node" {
   name       = "${format("%s-node-%s-%s", var.name, var.region, var.version)}"
@@ -217,7 +175,6 @@ data "template_file" "node_policy" {
 
   vars {
     name        = "${var.name}"
-    kms_key_arn = "${var.kms_key_arn}"
   }
 }
 

--- a/kubernetes/policies/controller-policy.json
+++ b/kubernetes/policies/controller-policy.json
@@ -19,15 +19,6 @@
     {
       "Effect": "Allow",
       "Action": [
-        "kms:Decrypt"
-      ],
-      "Resource": [
-        "${kms_key_arn}"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
         "ec2:*"
       ],
       "Resource": [

--- a/kubernetes/policies/node-policy.json
+++ b/kubernetes/policies/node-policy.json
@@ -18,15 +18,6 @@
     },
     {
       "Effect": "Allow",
-      "Action": [
-        "kms:Decrypt"
-      ],
-      "Resource": [
-        "${kms_key_arn}"
-      ]
-    },
-    {
-      "Effect": "Allow",
       "Action": "ec2:Describe*",
       "Resource": "*"
     },

--- a/vault/cloud-configs/vault.yaml
+++ b/vault/cloud-configs/vault.yaml
@@ -13,12 +13,12 @@ coreos:
         [Unit]
         Description=Pulls and runs vault
         After=vault-init.service
-        
+
         [Service]
         Restart=on-failure
         ExecStartPre=-/bin/docker kill vault
         ExecStartPre=-/bin/docker rm vault
-        ExecStartPre=/bin/docker create --cap-add=IPC_LOCK --name vault -p 8200:8200 -p 8201:8201 -v /etc/vault/tls:/opt/etc/tls -v /opt/vault:/opt/etc/vault quay.io/concur_platform/vault:0.6.4-5b34ba3 /opt/bin/vault server -config=/opt/etc/vault/environment.config -log-level=info
+        ExecStartPre=/bin/docker create --cap-add=IPC_LOCK --name vault -p 8200:8200 -p 8201:8201 -v /etc/vault/tls:/opt/etc/tls -v /opt/vault:/opt/etc/vault quay.io/concur_platform/vault:0.7.2-80ed185 /opt/bin/vault server -config=/opt/etc/vault/environment.config -log-level=info
         ExecStart=/bin/docker start -a vault
         ExecStop=/bin/docker stop -t 2 vault
     - name: vault-init.service


### PR DESCRIPTION
Since AWS China region doesn't have KMS, we decide to use user-defined script to bind PKI assets for `Kubernetes` and `Etcd` cluster quoins

For scipian, we will use [Vault](https://www.vaultproject.io/docs/secrets/pki/index.html) to create, store and revoke our PKI assets.